### PR TITLE
Properly escape filename of Python script.

### DIFF
--- a/plugin/sbt.vim
+++ b/plugin/sbt.vim
@@ -16,7 +16,7 @@
 " along with SBT-Vim.  If not, see <http://www.gnu.org/licenses/>.
 
 " TODO warn the user (and do nothing else) if Python is not supported
-let s:pysrc = expand("<sfile>:h") . "/../python/sbt-vim.py"
+let s:pysrc = fnameescape(expand("<sfile>:h") . "/../python/sbt-vim.py")
 exec "pyfile" s:pysrc
 
 cab sbtc py sbt_compile()


### PR DESCRIPTION
In cases where the path to the script contains spaces, the pyfile command was not functioning properly because it didn't treat the path as a single argument. Using fnameescape should fix this issue across all platforms.
